### PR TITLE
Remove seconds, regardless if it has AM/PM or not.

### DIFF
--- a/plugins/score-cycle-times.user.js
+++ b/plugins/score-cycle-times.user.js
@@ -57,7 +57,7 @@ window.plugin.scoreCycleTimes.update = function() {
 
   var formatRow = function(label,time) {
     var timeStr = unixTimeToString(time,true);
-    timeStr = timeStr.replace(/:00$/,''); //FIXME: doesn't remove seconds from AM/PM formatted dates
+    timeStr = timeStr.replace(/:00$|:00(?= [AP]M$)/,'');
 
     return '<tr><td>'+label+'</td><td>'+timeStr+'</td></tr>';
   }


### PR DESCRIPTION
This will trim the seconds, even if the string ends in AM or PM.
